### PR TITLE
Remove duplicate key entry for 'category_name'

### DIFF
--- a/snippets/categories.cson
+++ b/snippets/categories.cson
@@ -20,9 +20,6 @@
   'category_name':
     'prefix': 'category_name'
     'body': 'category_name'
-  'category_name':
-    'prefix': 'category_name'
-    'body': 'category_name'
   'category_reverse_count':
     'prefix': 'category_reverse_count'
     'body': 'category_reverse_count'


### PR DESCRIPTION
Duplicate key caused Atom to throw an error preventing the snippets from loading.

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Removed duplicate key for `category_name`.

### Alternate Designs

n/a

### Benefits

Snippets load.

### Possible Drawbacks

n/a

### Applicable Issues

n/a
